### PR TITLE
Use i2c-bus instead of i2c

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "description": "14 segments library for HT16K33",
   "dependencies": {
-    "i2c": "^0.2.3",
+    "i2c-bus": "^4.0.7",
     "moment": "^2.22.2"
   },
   "main": "index.js",


### PR DESCRIPTION
Due to upstream bug compiling i2c on node v10:
https://github.com/kelly/node-i2c/issues/90